### PR TITLE
fix: use dynamic version from Cargo.toml instead of hardcoded value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,7 @@ checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "blindfold"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "async-trait",
  "clap",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,7 +4,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 #[derive(Parser)]
 #[command(
     name = "Blindfold",
-    version = "1.0",
+    version = env!("CARGO_PKG_VERSION"),
     author = "Eoin McMahon",
     about = "Generator of .gitignore files using gitignore.io"
 )]


### PR DESCRIPTION
rather than having version info in two places, update to use the version info from `cargo.toml`